### PR TITLE
Add compatibility with odin-data changes and recent firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,11 @@
 *.exe
 *.out
 *.app
+
+# Python virtual environments
+venv*
+
+# Eclipse project metadata files
 /.cproject
 /.project
+/.pydevproject

--- a/data/common/include/PercivalEmulatorDefinitions.h
+++ b/data/common/include/PercivalEmulatorDefinitions.h
@@ -21,16 +21,28 @@ namespace PercivalEmulator {
     static const size_t num_subframes          = 2;
     static const size_t num_data_types         = 2;
 
-    static const size_t packet_header_size     = 54; // NB As of 25/1/16 firmware incomplete so fields are not properly implemented
-    static const size_t pixel_data_size_offset = 0;  // not yet present
-    static const size_t packet_type_offset     = 0;  // should be 2
-    static const size_t subframe_number_offset = 1;  // should be 3
-    static const size_t frame_number_offset    = 2;  // should be 4
-    static const size_t packet_number_offset   = 6;  // should be 8
-    static const size_t packet_offset_offset   = 10; // not yet present
-    static const size_t frame_info_offset      = 8;  // should be 12
+//    static const size_t packet_header_size     = 54; // NB As of 25/1/16 firmware incomplete so fields are not properly implemented
+//    static const size_t pixel_data_size_offset = 0;  // not yet present
+//    static const size_t packet_type_offset     = 0;  // should be 2
+//    static const size_t subframe_number_offset = 1;  // should be 3
+//    static const size_t frame_number_offset    = 2;  // should be 4
+//    static const size_t packet_number_offset   = 6;  // should be 8
+//    static const size_t packet_offset_offset   = 10; // not yet present
+//    static const size_t frame_info_offset      = 8;  // should be 12
+
+    static const size_t packet_header_size     = 54;
+    static const size_t pixel_data_size_offset = 0;
+    static const size_t packet_type_offset     = 2;
+    static const size_t subframe_number_offset = 3;
+    static const size_t frame_number_offset    = 4;
+    static const size_t packet_number_offset   = 8;
+    static const size_t packet_offset_offset   = 10;
+    static const size_t frame_info_offset      = 12;
 
     static const size_t frame_info_size        = 42;
+
+    static const size_t reference_packet_size = 448;
+    static const uint8_t reference_packet_subframe_number = 0x80;
 
 #else
 

--- a/data/frameProcessor/include/PercivalProcessPlugin.h
+++ b/data/frameProcessor/include/PercivalProcessPlugin.h
@@ -39,6 +39,9 @@ namespace FrameProcessor
 
     /** Pointer to logger */
     LoggerPtr logger_;
+
+    /* Frame counter */
+    uint32_t frame_counter_;
   };
 
   /**

--- a/data/frameProcessor/src/PercivalProcessPlugin.cpp
+++ b/data/frameProcessor/src/PercivalProcessPlugin.cpp
@@ -10,7 +10,8 @@
 namespace FrameProcessor
 {
 
-  PercivalProcessPlugin::PercivalProcessPlugin()
+  PercivalProcessPlugin::PercivalProcessPlugin() :
+          frame_counter_(0)
   {
     // Setup logging for the class
     logger_ = Logger::getLogger("FW.PercivalProcessPlugin");
@@ -37,7 +38,7 @@ namespace FrameProcessor
 
     // Read out the frame header from the raw frame
     const PercivalEmulator::FrameHeader* hdrPtr = static_cast<const PercivalEmulator::FrameHeader*>(frame->get_data());
-    LOG4CXX_TRACE(logger_, "Raw frame number: " << hdrPtr->frame_number);
+    LOG4CXX_TRACE(logger_, "Raw frame number: " << hdrPtr->frame_number << " offset frame number: " << frame_counter_);
 
     // Raw frame arrive as two sub-frames stored incorrectly in memory
     // -------------------
@@ -56,7 +57,7 @@ namespace FrameProcessor
 
     boost::shared_ptr<Frame> reset_frame;
     reset_frame = boost::shared_ptr<Frame>(new Frame("reset"));
-    reset_frame->set_frame_number(hdrPtr->frame_number);
+    reset_frame->set_frame_number(frame_counter_);
     reset_frame->set_dimensions("reset", p2m_dims);
     // Copy data into frame
     // TODO: This is a fudge as the Frame object will not permit write access to the memory
@@ -81,7 +82,7 @@ namespace FrameProcessor
 
     boost::shared_ptr<Frame> data_frame;
     data_frame = boost::shared_ptr<Frame>(new Frame("data"));
-    data_frame->set_frame_number(hdrPtr->frame_number);
+    data_frame->set_frame_number(frame_counter_);
     data_frame->set_dimensions("data", p2m_dims);
     // Copy data into frame
     // TODO: This is a fudge as the Frame object will not permit write access to the memory
@@ -106,6 +107,9 @@ namespace FrameProcessor
 
     // Free temporary memory allocation
     free(tmp_mem_ptr);
+
+    // Increment local frame counter
+    frame_counter_++;
 
   }
 

--- a/data/frameReceiver/include/PercivalEmulatorFrameDecoder.h
+++ b/data/frameReceiver/include/PercivalEmulatorFrameDecoder.h
@@ -24,7 +24,7 @@ namespace FrameReceiver
         PercivalEmulatorFrameDecoder();
         ~PercivalEmulatorFrameDecoder();
 
-        void init(LoggerPtr& logger, bool enable_packet_logging=false, unsigned int frame_timeout_ms=1000);
+        void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg);
 
         const size_t get_frame_buffer_size(void) const;
         const size_t get_frame_header_size(void) const;
@@ -60,11 +60,14 @@ namespace FrameReceiver
 
         boost::shared_ptr<void> current_packet_header_;
         boost::shared_ptr<void> dropped_frame_buffer_;
+        boost::shared_ptr<void> reference_packet_buffer_;
 
         int current_frame_seen_;
         int current_frame_buffer_id_;
         void* current_frame_buffer_;
         PercivalEmulator::FrameHeader* current_frame_header_;
+
+        unsigned int reference_packets_seen_;
 
         bool dropping_frame_data_;
 

--- a/data/frameReceiver/test/CMakeLists.txt
+++ b/data/frameReceiver/test/CMakeLists.txt
@@ -3,14 +3,27 @@ set(CMAKE_INCLUDE_CURRENT_DIR on)
 ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
 ADD_DEFINITIONS(-DBUILD_DIR="${CMAKE_BINARY_DIR}")
 
-include_directories(${FRAMERECEIVER_DIR}/include ${ODINDATA_INCLUDE_DIRS} 
-	${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS})
+set(FRAMERECEIVER_MAIN_DIR ${ODINDATA_ROOTDIR}/frameReceiver)
+set(FRAMERECEIVER_MAIN_SOURCE_DIR ${FRAMERECEIVER_MAIN_DIR}/src)
+set(FRAMERECEIVER_MAIN_INCLUDE_DIR ${FRAMERECEIVER_MAIN_DIR}/include)
+
+include_directories(${FRAMERECEIVER_DIR}/include 
+					${FRAMERECEIVER_MAIN_INCLUDE_DIR} 
+					${ODINDATA_INCLUDE_DIRS} 
+					${Boost_INCLUDE_DIRS} 
+					${LOG4CXX_INCLUDE_DIRS}/.. 
+					${ZEROMQ_INCLUDE_DIRS})
 
 # Build list of test source files from current dir
 file(GLOB TEST_SOURCES *.cpp)
 
+# Build list of main project source files from src dir but exclude application main
+file(GLOB APP_SOURCES ${FRAMERECEIVER_MAIN_SOURCE_DIR}/*.cpp)
+file(GLOB APP_MAIN_SOURCE ${FRAMERECEIVER_MAIN_SOURCE_DIR}/FrameReceiverApp.cpp)
+list(REMOVE_ITEM APP_SOURCES ${APP_MAIN_SOURCE})
+
 # Add test and project source files to executable
-add_executable(percivalFrameReceiverTest ${TEST_SOURCES})
+add_executable(percivalFrameReceiverTest ${TEST_SOURCES} ${APP_SOURCES})
 
 if ( ${CMAKE_SYSTEM_NAME} MATCHES Linux )
 # librt required for timing functions

--- a/data/frameReceiver/test/PercivalEmulatorFrameDecoderUnitTest.cpp
+++ b/data/frameReceiver/test/PercivalEmulatorFrameDecoderUnitTest.cpp
@@ -35,7 +35,8 @@ BOOST_FIXTURE_TEST_SUITE(FrameDecoderUnitTest, FrameDecoderTestFixture);
 BOOST_AUTO_TEST_CASE( PercivalEmulatorDecoderTest )
 {
     boost::shared_ptr<FrameReceiver::FrameDecoderUDP> decoder(new FrameReceiver::PercivalEmulatorFrameDecoder());
-    decoder->init(logger);
+    OdinData::IpcMessage config_msg;
+    decoder->init(logger, config_msg);
 
     BOOST_TEST_MESSAGE("Emulator buffer size is specified as " << decoder->get_frame_buffer_size());
     BOOST_TEST_MESSAGE("Emulator frame header size is specified as " << decoder->get_frame_header_size());

--- a/data/tools/python/decode_raw_frames_hdf5.py
+++ b/data/tools/python/decode_raw_frames_hdf5.py
@@ -25,7 +25,7 @@ def main():
     fname = args.file
     print fname
 
-    with h5py.File(fname, 'r+') as f:
+    with h5py.File(fname, 'r+', libver='latest') as f:
         print f.items()
         
         for name, raw_dset in f.items():  


### PR DESCRIPTION
This PR adds compatibility with recent odin-data changes, namely PRs to implement FR client control, and refactoring of FP file writer plugin (removing subframe behaviour). Also updated to support most recent emulator firmware versions (3 and 1 link) containing a more complete packet header implementation (fields in correct byte locations) and reference packets (which are currently discarded by the FR decoder plugin).

N.B. CI jobs will fail on this PR until percival-detector/odin-data repo merges in the core version.